### PR TITLE
fix: make agent_observe consistent with agent to avoid err

### DIFF
--- a/src/agent_observe.ts
+++ b/src/agent_observe.ts
@@ -10,11 +10,10 @@ import { getPrompt } from "./helpers/prompt.js";
 import { WikipediaTool } from "bee-agent-framework/tools/search/wikipedia";
 
 const llm = getChatLLM();
-
 const agent = new BeeAgent({
   llm,
   memory: new TokenMemory({ llm }),
-  tools: [new WikipediaTool(), new OpenMeteoTool()],
+  tools: [new OpenMeteoTool(), new WikipediaTool()],
 });
 
 try {
@@ -28,7 +27,7 @@ try {
         execution: {
           maxIterations: 8,
           maxRetriesPerStep: 3,
-          totalMaxRetries: 10,
+          totalMaxRetries: 0,
         },
       },
     )


### PR DESCRIPTION
When running the agent_observe.ts example with a simple ollama setup, I was getting this error:

>  LinePrefixParserError: The generated output does not adhere to the schema.  Nothing valid has been parsed yet!

agent.ts works fine, so fixing the tool order and totalMaxRetries to be more consistent and to avoid the error.

Closes: #11 